### PR TITLE
movinfo를 seqinfo에 포함시킴

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,5 @@
-fields = ["plate", "frame_in", "frame_out", "duration", "tc_in", "tc_out"]
+fields = ["plate", "frame_rate", "frame_in", "frame_out", "duration", "tc_in", "tc_out", "codec", "colorspace"]
+
 
 [seq]
 
@@ -26,6 +27,7 @@ value = """{{output "oiiotool" $.FirstFile "--echo" "{TOP.'smpte:Timecode'}"}}""
 name = "tc_out"
 value = """{{output "oiiotool" $.LastFile "--echo" "{TOP.'smpte:Timecode'}"}}"""
 
+
 [mov]
 
 [[mov.fields]]
@@ -33,13 +35,25 @@ name = "plate"
 value = "{{abspath $.File}}"
 
 [[mov.fields]]
+name = "codec"
+value = "{{$.Codec}}"
+
+[[mov.fields]]
+name = "colorspace"
+value = "{{$.Colorspace}}"
+
+[[mov.fields]]
 name = "duration"
-value = """{{output "bin/movinfo" "-duration" $.File}}"""
+value = "{{$.Duration}}"
+
+[[mov.fields]]
+name = "frame_rate"
+value = "{{$.FPS}}"
 
 [[mov.fields]]
 name = "tc_in"
-value = """{{output "bin/movinfo" "-start" $.File}}"""
+value = "{{$.TimecodeIn}}"
 
 [[mov.fields]]
 name = "tc_out"
-value = """{{output "bin/movinfo" "-end" $.File}}"""
+value = "{{$.TimecodeOut}}"

--- a/main.go
+++ b/main.go
@@ -95,10 +95,6 @@ func (s *Sequence) Length() string {
 
 var ReSplitSeqName = regexp.MustCompile(`(.*\D)?(\d+)(.*?)$`)
 
-type Mov struct {
-	File string
-}
-
 type Table struct {
 	sync.Mutex
 	Cells [][]string
@@ -240,7 +236,11 @@ func main() {
 			}
 		}
 		if foundMov {
-			movs = append(movs, &Mov{File: path})
+			mov, err := parseMov(path, verboseFlag)
+			if err != nil {
+				log.Fatal(err)
+			}
+			movs = append(movs, mov)
 		}
 		return nil
 	})
@@ -270,6 +270,7 @@ func main() {
 	numConcurrent := 8
 	for i := 0; i < numConcurrent; i++ {
 		go func() {
+			// Concurrently process each cell.
 			for {
 				select {
 				case ex := <-ch:

--- a/mov.go
+++ b/mov.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// Mov is a mov info that will be used by seqinfo.
+type Mov struct {
+	File        string
+	TimecodeIn  string
+	TimecodeOut string
+	Duration    string
+	FPS         string
+	Resolution  string
+	Codec       string
+	Colorspace  string
+}
+
+// ffOutput is a mov info got by ffprobe.
+type ffOutput struct {
+	Streams []ffStream `json:"streams"`
+	Format  ffFormat   `json:"format"`
+}
+
+// ffStream is a mov stream info got by ffprobe.
+// There is video streams and audio streams, but we only need video info.
+type ffStream struct {
+	NbFrames   string       `json:"nb_frames"`
+	RFrameRate string       `json:"r_frame_rate"`
+	CodecName  string       `json:"codec_name"`
+	Profile    string       `json:"profile"`
+	Width      int          `json:"width"`
+	Height     int          `json:"height"`
+	Tags       ffStreamTags `json:"tags"`
+}
+
+// ffStreamTags is a mov stream tag info got by ffprobe.
+type ffStreamTags struct {
+	Timecode string `json:"timecode"`
+}
+
+// ffFormat is a mov format info got by ffprobe.
+type ffFormat struct {
+	Tags ffFormatTags `json:"tags"`
+}
+
+// ffFormatTags is a mov format tag info got by ffprobe.
+type ffFormatTags struct {
+	FoundryColorspace string `json:"uk.co.thefoundry.Colorspace"`
+}
+
+// parseMov got a mov file path and parses its info.
+// If verbose is true, it will put error message in the field when there is a missing info,
+// instead of leaving it empty.
+// It will only return an error, when there is a crucial error occurred while running ffprobe.
+func parseMov(file string, verbose bool) (*Mov, error) {
+	c := exec.Command("ffprobe", "-v", "quiet", "-show_format", "-show_streams", "-select_streams", "v:0", "-of", "json", file)
+	b, err := c.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute: %s", b)
+	}
+	mov, err := parseMovinfo(b, verbose)
+	if err != nil {
+		return nil, err
+	}
+	mov.File = file
+	return mov, nil
+}
+
+func parseMovinfo(info []byte, verbose bool) (*Mov, error) {
+	ff := ffOutput{}
+	err := json.Unmarshal(info, &ff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal: %v", err)
+	}
+	if len(ff.Streams) > 1 {
+		return nil, fmt.Errorf("too many video streams")
+	}
+	if len(ff.Streams) == 0 {
+		return nil, fmt.Errorf("no video streams")
+	}
+	video := ff.Streams[0]
+	mov := &Mov{}
+	if err != nil && verbose {
+		mov.TimecodeIn = err.Error()
+	}
+	mov.TimecodeIn, err = func() (string, error) {
+		if video.Tags.Timecode == "" {
+			// timecode may not exists
+			return "", nil
+		}
+		return video.Tags.Timecode, nil
+	}()
+	if err != nil && verbose {
+		mov.TimecodeIn = err.Error()
+	}
+	mov.TimecodeOut, err = func() (string, error) {
+		if video.Tags.Timecode == "" {
+			// timecode may not exists
+			return "", nil
+		}
+		if video.RFrameRate == "" {
+			return "", fmt.Errorf("missing r_frame_rate information")
+		}
+		if video.NbFrames == "" {
+			return "", fmt.Errorf("missing nb_frames information")
+		}
+		var base int
+		var drop bool
+		switch video.RFrameRate {
+		case "24/1":
+			base = 24
+			drop = false
+		case "24000/1001":
+			base = 24
+			drop = true
+		case "30/1":
+			base = 30
+			drop = false
+		default:
+			return "", fmt.Errorf("unknown r_frame_rate: %v", video.RFrameRate)
+		}
+		tc, err := NewTimecode(video.Tags.Timecode, base, drop)
+		if err != nil {
+			return "", err
+		}
+		frames, err := strconv.Atoi(video.NbFrames)
+		if err != nil {
+			return "", err
+		}
+		tc.Add(frames - 1)
+		return tc.String(), nil
+	}()
+	if err != nil && verbose {
+		mov.TimecodeOut = err.Error()
+	}
+	mov.Duration, err = func() (string, error) {
+		if video.NbFrames == "" {
+			return "", fmt.Errorf("missing nb_frames information")
+		}
+		return video.NbFrames, nil
+	}()
+	if err != nil && verbose {
+		mov.Duration = err.Error()
+	}
+	mov.FPS, err = func() (string, error) {
+		if video.RFrameRate == "" {
+			return "", fmt.Errorf("missing r_frame_rate information")
+		}
+		var fps string
+		switch video.RFrameRate {
+		case "24/1":
+			fps = "24"
+		case "24000/1001":
+			fps = "23.976"
+		case "30/1":
+			fps = "30"
+		default:
+			return "", fmt.Errorf("unknown r_frame_rate: %v", video.RFrameRate)
+		}
+		return fps, nil
+	}()
+	if err != nil && verbose {
+		mov.FPS = err.Error()
+	}
+	mov.Resolution, err = func() (string, error) {
+		if video.Width == 0 {
+			return "", fmt.Errorf("missing width information")
+		}
+		if video.Height == 0 {
+			return "", fmt.Errorf("missing height information")
+		}
+		return strconv.Itoa(video.Width) + "*" + strconv.Itoa(video.Height), nil
+	}()
+	if err != nil && verbose {
+		mov.Resolution = err.Error()
+	}
+	mov.Codec, err = func() (string, error) {
+		if video.CodecName == "" {
+			return "", fmt.Errorf("missing codec_name information")
+		}
+		if video.Profile == "" {
+			return "", fmt.Errorf("missing codec_profile information")
+		}
+		codec := strings.Title(strings.ToLower(video.CodecName)) + " " + video.Profile
+		return codec, nil
+	}()
+	if err != nil && verbose {
+		mov.Codec = err.Error()
+	}
+	mov.Colorspace, err = func() (string, error) {
+		tags := ff.Format.Tags
+		if tags.FoundryColorspace != "" {
+			return tags.FoundryColorspace, nil
+		}
+		return "", nil
+	}()
+	if err != nil && verbose {
+		mov.Colorspace = err.Error()
+	}
+	return mov, nil
+}

--- a/mov_test.go
+++ b/mov_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"io/ioutil"
+	"reflect"
+	"testing"
+)
+
+func TestParseMov(t *testing.T) {
+	cases := []struct {
+		file    string
+		verbose bool
+		want    *Mov
+	}{
+		{
+			file:    "testdata/ffprobe1.output",
+			verbose: false,
+			want: &Mov{
+				FPS:         "23.976",
+				TimecodeIn:  "00:00:00:00",
+				TimecodeOut: "00:00:00:21",
+				Duration:    "22",
+				Resolution:  "1920*1080",
+				Codec:       "Prores HQ",
+			},
+		},
+		{
+			file:    "testdata/ffprobe2.output",
+			verbose: false,
+			want: &Mov{
+				FPS:         "23.976",
+				TimecodeIn:  "00:00:00:00",
+				TimecodeOut: "00:00:04:10",
+				Duration:    "107",
+				Resolution:  "1920*1080",
+				Codec:       "Prores HQ",
+				Colorspace:  "rec709",
+			},
+		},
+		{
+			file:    "testdata/ffprobe3.output",
+			verbose: false,
+			want: &Mov{
+				FPS:         "23.976",
+				TimecodeIn:  "12:14:20:17",
+				TimecodeOut: "12:14:21:22",
+				Duration:    "30",
+				Resolution:  "1920*1080",
+				Codec:       "Prores HQ",
+			},
+		},
+		{
+			file:    "testdata/ffprobe4.output",
+			verbose: false,
+			want: &Mov{
+				FPS:         "23.976",
+				TimecodeIn:  "00:00:00:00",
+				TimecodeOut: "00:00:01:04",
+				Duration:    "29",
+				Resolution:  "1920*1134",
+				Codec:       "Prores Standard",
+				Colorspace:  "Output - Rec.709",
+			},
+		},
+	}
+	for _, c := range cases {
+		info, err := ioutil.ReadFile(c.file)
+		if err != nil {
+			t.Fatalf("read error: %v", err)
+		}
+		got, err := parseMovinfo(info, c.verbose)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Fatalf("got %v, want %v", got, c.want)
+		}
+	}
+}

--- a/testdata/ffprobe1.output
+++ b/testdata/ffprobe1.output
@@ -1,0 +1,77 @@
+{
+    "streams": [
+        {
+            "index": 0,
+            "codec_name": "prores",
+            "codec_long_name": "Apple ProRes (iCodec Pro)",
+            "profile": "HQ",
+            "codec_type": "video",
+            "codec_time_base": "1001/24000",
+            "codec_tag_string": "apch",
+            "codec_tag": "0x68637061",
+            "width": 1920,
+            "height": 1080,
+            "coded_width": 1920,
+            "coded_height": 1080,
+            "has_b_frames": 0,
+            "sample_aspect_ratio": "1:1",
+            "display_aspect_ratio": "16:9",
+            "pix_fmt": "yuv422p10le",
+            "level": -99,
+            "color_range": "tv",
+            "color_space": "bt709",
+            "color_transfer": "bt709",
+            "color_primaries": "bt709",
+            "field_order": "progressive",
+            "refs": 1,
+            "r_frame_rate": "24000/1001",
+            "avg_frame_rate": "24000/1001",
+            "time_base": "1/24000",
+            "start_pts": 0,
+            "start_time": "0.000000",
+            "duration_ts": 22022,
+            "duration": "0.917583",
+            "bit_rate": "185453760",
+            "bits_per_raw_sample": "10",
+            "nb_frames": "22",
+            "disposition": {
+                "default": 1,
+                "dub": 0,
+                "original": 0,
+                "comment": 0,
+                "lyrics": 0,
+                "karaoke": 0,
+                "forced": 0,
+                "hearing_impaired": 0,
+                "visual_impaired": 0,
+                "clean_effects": 0,
+                "attached_pic": 0,
+                "timed_thumbnails": 0
+            },
+            "tags": {
+                "creation_time": "2024-04-05T15:48:08.000000Z",
+                "language": "eng",
+                "handler_name": "Apple Video Media Handler",
+                "encoder": "Apple ProRes 422 HQ",
+                "timecode": "00:00:00:00"
+            }
+        }
+    ],
+    "format": {
+        "nb_streams": 2,
+        "nb_programs": 0,
+        "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
+        "format_long_name": "QuickTime / MOV",
+        "start_time": "0.000000",
+        "duration": "0.917583",
+        "size": "22319740",
+        "bit_rate": "194595933",
+        "probe_score": 100,
+        "tags": {
+            "major_brand": "qt  ",
+            "minor_version": "537199360",
+            "compatible_brands": "qt  ",
+            "creation_time": "2024-04-05T15:48:08.000000Z"
+        }
+    }
+}

--- a/testdata/ffprobe2.output
+++ b/testdata/ffprobe2.output
@@ -1,0 +1,79 @@
+{
+    "streams": [
+        {
+            "index": 0,
+            "codec_name": "prores",
+            "codec_long_name": "Apple ProRes (iCodec Pro)",
+            "profile": "HQ",
+            "codec_type": "video",
+            "codec_time_base": "1001/24000",
+            "codec_tag_string": "apch",
+            "codec_tag": "0x68637061",
+            "width": 1920,
+            "height": 1080,
+            "coded_width": 1920,
+            "coded_height": 1080,
+            "has_b_frames": 0,
+            "sample_aspect_ratio": "1:1",
+            "display_aspect_ratio": "16:9",
+            "pix_fmt": "yuv422p10le",
+            "level": -99,
+            "color_range": "tv",
+            "color_space": "bt709",
+            "color_transfer": "bt709",
+            "color_primaries": "bt709",
+            "field_order": "progressive",
+            "refs": 1,
+            "r_frame_rate": "24000/1001",
+            "avg_frame_rate": "24000/1001",
+            "time_base": "1/24000",
+            "start_pts": 0,
+            "start_time": "0.000000",
+            "duration_ts": 107107,
+            "duration": "4.462792",
+            "bit_rate": "100594397",
+            "bits_per_raw_sample": "10",
+            "nb_frames": "107",
+            "disposition": {
+                "default": 1,
+                "dub": 0,
+                "original": 0,
+                "comment": 0,
+                "lyrics": 0,
+                "karaoke": 0,
+                "forced": 0,
+                "hearing_impaired": 0,
+                "visual_impaired": 0,
+                "clean_effects": 0,
+                "attached_pic": 0,
+                "timed_thumbnails": 0
+            },
+            "tags": {
+                "handler_name": "VideoHandler",
+                "timecode": "00:00:00:00"
+            }
+        }
+    ],
+    "format": {
+        "nb_streams": 2,
+        "nb_programs": 0,
+        "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
+        "format_long_name": "QuickTime / MOV",
+        "start_time": "0.000000",
+        "duration": "4.463000",
+        "size": "56119102",
+        "bit_rate": "100594401",
+        "probe_score": 100,
+        "tags": {
+            "major_brand": "qt  ",
+            "minor_version": "512",
+            "compatible_brands": "qt  ",
+            "encoder": "Apple ProRes",
+            "uk.co.thefoundry.Application": "Nuke",
+            "uk.co.thefoundry.ApplicationVersion": "15.0v4",
+            "uk.co.thefoundry.YCbCrMatrix": "Rec 709",
+            "uk.co.thefoundry.Colorspace": "rec709",
+            "uk.co.thefoundry.Writer": "mov64"
+        }
+    }
+}

--- a/testdata/ffprobe3.output
+++ b/testdata/ffprobe3.output
@@ -1,0 +1,76 @@
+{
+    "streams": [
+        {
+            "index": 0,
+            "codec_name": "prores",
+            "codec_long_name": "Apple ProRes (iCodec Pro)",
+            "profile": "HQ",
+            "codec_type": "video",
+            "codec_time_base": "1001/24000",
+            "codec_tag_string": "apch",
+            "codec_tag": "0x68637061",
+            "width": 1920,
+            "height": 1080,
+            "coded_width": 1920,
+            "coded_height": 1080,
+            "has_b_frames": 0,
+            "sample_aspect_ratio": "1:1",
+            "display_aspect_ratio": "16:9",
+            "pix_fmt": "yuv422p10le",
+            "level": -99,
+            "color_range": "tv",
+            "color_space": "bt709",
+            "color_primaries": "bt709",
+            "field_order": "progressive",
+            "refs": 1,
+            "r_frame_rate": "24000/1001",
+            "avg_frame_rate": "24000/1001",
+            "time_base": "1/24000",
+            "start_pts": 0,
+            "start_time": "0.000000",
+            "duration_ts": 30030,
+            "duration": "1.251250",
+            "bit_rate": "170907850",
+            "bits_per_raw_sample": "10",
+            "nb_frames": "30",
+            "disposition": {
+                "default": 1,
+                "dub": 0,
+                "original": 0,
+                "comment": 0,
+                "lyrics": 0,
+                "karaoke": 0,
+                "forced": 0,
+                "hearing_impaired": 0,
+                "visual_impaired": 0,
+                "clean_effects": 0,
+                "attached_pic": 0,
+                "timed_thumbnails": 0
+            },
+            "tags": {
+                "creation_time": "2023-11-03T08:38:11.000000Z",
+                "handler_name": "VideoHandler",
+                "encoder": "Apple ProRes 422 HQ",
+                "timecode": "12:14:20:17"
+            }
+        }
+    ],
+    "format": {
+        "nb_streams": 2,
+        "nb_programs": 0,
+        "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
+        "format_long_name": "QuickTime / MOV",
+        "start_time": "0.000000",
+        "duration": "1.251250",
+        "size": "26732768",
+        "bit_rate": "170918796",
+        "probe_score": 100,
+        "tags": {
+            "major_brand": "qt  ",
+            "minor_version": "512",
+            "compatible_brands": "qt  ",
+            "creation_time": "2023-11-03T08:38:11.000000Z",
+            "encoder": "Blackmagic Design DaVinci Resolve Studio"
+        }
+    }
+}

--- a/testdata/ffprobe4.output
+++ b/testdata/ffprobe4.output
@@ -1,0 +1,79 @@
+{
+    "streams": [
+        {
+            "index": 0,
+            "codec_name": "prores",
+            "codec_long_name": "Apple ProRes (iCodec Pro)",
+            "profile": "Standard",
+            "codec_type": "video",
+            "codec_time_base": "1001/24000",
+            "codec_tag_string": "apcn",
+            "codec_tag": "0x6e637061",
+            "width": 1920,
+            "height": 1134,
+            "coded_width": 1920,
+            "coded_height": 1134,
+            "has_b_frames": 0,
+            "sample_aspect_ratio": "1:1",
+            "display_aspect_ratio": "320:189",
+            "pix_fmt": "yuv422p10le",
+            "level": -99,
+            "color_range": "tv",
+            "color_space": "bt709",
+            "color_transfer": "bt709",
+            "color_primaries": "bt709",
+            "field_order": "progressive",
+            "refs": 1,
+            "r_frame_rate": "24000/1001",
+            "avg_frame_rate": "24000/1001",
+            "time_base": "1/24000",
+            "start_pts": 0,
+            "start_time": "0.000000",
+            "duration_ts": 29029,
+            "duration": "1.209542",
+            "bit_rate": "87262197",
+            "bits_per_raw_sample": "10",
+            "nb_frames": "29",
+            "disposition": {
+                "default": 1,
+                "dub": 0,
+                "original": 0,
+                "comment": 0,
+                "lyrics": 0,
+                "karaoke": 0,
+                "forced": 0,
+                "hearing_impaired": 0,
+                "visual_impaired": 0,
+                "clean_effects": 0,
+                "attached_pic": 0,
+                "timed_thumbnails": 0
+            },
+            "tags": {
+                "handler_name": "VideoHandler",
+                "timecode": "00:00:00:00"
+            }
+        }
+    ],
+    "format": {
+        "nb_streams": 2,
+        "nb_programs": 0,
+        "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
+        "format_long_name": "QuickTime / MOV",
+        "start_time": "0.000000",
+        "duration": "1.210000",
+        "size": "13195416",
+        "bit_rate": "87242419",
+        "probe_score": 100,
+        "tags": {
+            "major_brand": "qt  ",
+            "minor_version": "512",
+            "compatible_brands": "qt  ",
+            "encoder": "Apple ProRes",
+            "uk.co.thefoundry.Application": "Nuke",
+            "uk.co.thefoundry.ApplicationVersion": "13.1v4",
+            "uk.co.thefoundry.YCbCrMatrix": "Rec 709",
+            "uk.co.thefoundry.Colorspace": "Output - Rec.709",
+            "uk.co.thefoundry.Writer": "mov64"
+        }
+    }
+}

--- a/timecode.go
+++ b/timecode.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Timecode is timecode system that supports 24 and 30 base fps.
+// See introduction of drop frame timecode system at http://andrewduncan.net/timecodes/
+type Timecode struct {
+	// base is base frame rate for timecode
+	// ex) base frame rate of 29.976 fps is 30.
+	base  int
+	drop  bool
+	frame int
+}
+
+// NewTimecode creates new Timecode.
+func NewTimecode(code string, base int, drop bool) (*Timecode, error) {
+	if base != 24 && base != 30 {
+		return nil, fmt.Errorf("unknown base for timecode: %v:", base)
+	}
+	if base == 24 && drop {
+		// 23.98, 23.978 isn't a drop timecode system.
+		drop = false
+	}
+	if len(code) != 11 {
+		return nil, fmt.Errorf("invalid timecode: %v", code)
+	}
+	codes := [4]int{}
+	for i := 0; i < len(code); i += 3 {
+		n, err := strconv.Atoi(code[i : i+2])
+		if err != nil {
+			return nil, fmt.Errorf("invalid timecode: %v", code)
+		}
+		codes[i/3] = n
+	}
+	h := codes[0]
+	m := codes[1]
+	s := codes[2]
+	f := codes[3]
+	frame := 3600*h*base + 60*m*base + s*base + f
+	if drop {
+		// assume it is base 30
+		totalMinutes := 60*h + m
+		frame -= 2 * (totalMinutes - totalMinutes/10)
+	}
+	t := &Timecode{
+		base:  base,
+		drop:  drop,
+		frame: frame,
+	}
+	return t, nil
+}
+
+// Add adds frames to the Timecode.
+func (t *Timecode) Add(n int) {
+	t.frame += n
+}
+
+// String represents the Timecode as string.
+func (t *Timecode) String() string {
+	base := t.base
+	frame := t.frame
+	if t.drop {
+		// assume it is base 30
+		D := frame / 17982  // number of "full" 10 minutes chunks in drop frame system
+		M := frame % 17982  // remainder frames
+		d := (M - 2) / 1798 // number of 1 minute chunks those drop frames; M-2 because the first chunk will not drop frames
+		frame += 18*D + 2*d // 10 minutes chunks drop 18 frames; 1 minute chunks drop 2 frames
+	}
+	h := frame / base / 60 / 60 % 24
+	m := frame / base / 60 % 60
+	s := frame / base % 60
+	f := frame % base
+	codes := [4]int{h, m, s, f}
+	timecode := ""
+	for i, c := range codes {
+		if i == 1 || i == 2 {
+			timecode += ":"
+		}
+		if i == 3 {
+			if t.drop {
+				timecode += ";"
+			} else {
+				timecode += ":"
+			}
+		}
+		tc := strconv.Itoa(c)
+		if len(tc) == 1 {
+			tc = "0" + tc
+		}
+		timecode += tc
+	}
+	return timecode
+}


### PR DESCRIPTION
원래 movinfo는 독립된 툴이었으나 항상 프로그램 두개를 컴파일하기
불편하여 이번에 포함시킵니다.

포함하면서 원래는 파싱하지 않았던 fps를 추가하고,
또 잘못된 정보를 보여주었던 colorspace 정보를 수정하였습니다.